### PR TITLE
Fix error due to duplicate rows in model

### DIFF
--- a/etl/jobs/transformation/model_transformer_job.py
+++ b/etl/jobs/transformation/model_transformer_job.py
@@ -91,8 +91,10 @@ def set_fk_accessibility_group(model_df: DataFrame, accessibility_group_df: Data
 
 
 def set_fk_contact_people(model_df: DataFrame, contact_people_df: DataFrame) -> DataFrame:
-    model_df = transform_to_fk(
-        model_df, contact_people_df, "email", "email_list", "id", "contact_people_id")
+    model_df = model_df.withColumnRenamed("email", "email_list")
+    model_df = model_df.withColumnRenamed("name", "name_list")
+    contact_people_df = contact_people_df.withColumnRenamed("id", "contact_people_id")
+    model_df = model_df.join(contact_people_df, on=['name_list', 'email_list'])
     return model_df
 
 

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -61,7 +61,7 @@ CREATE TABLE publication_group (
 
 CREATE TABLE accessibility_group (
     id BIGINT NOT NULL,
-    europdx_access_modalities TEXT NOT NULL,
+    europdx_access_modalities TEXT,
     accessibility TEXT,
     PRIMARY KEY (id)
 );


### PR DESCRIPTION
- The join between model and contact_person was resulting in more rows than expected. The join needs to to involve not only the email but also the name.
- europdx_access_modalities can be null (e.g CRL)