### PR TITLE
Fix error by processing null row for provider group

### DIFF
--- a/etl/jobs/transformation/provider_group_transformer_job.py
+++ b/etl/jobs/transformation/provider_group_transformer_job.py
@@ -70,7 +70,7 @@ def extract_data_loader(raw_loader_df: DataFrame) -> DataFrame:
         "abbreviation",
         "internal_url",
         Constants.DATA_SOURCE_COLUMN
-    )
+    ).where("abbreviation is not null")
     data_from_loader_df = data_from_loader_df.drop_duplicates()
     return data_from_loader_df
 


### PR DESCRIPTION
- Filter out empty records in provider_group_transformer that were leading to duplicate records in patient when the join was done