### PR TITLE
Define explicitly the columns by table when converting parquet files to csv

### DIFF
--- a/etl/entities.yaml
+++ b/etl/entities.yaml
@@ -1,0 +1,193 @@
+entities:
+  - entity: "diagnosis"
+    columns:
+        - "id"
+        - "name"
+
+  - entity: "ethnicity"
+    columns:
+        - "id"
+        - "name"
+
+  - entity: "model"
+    columns:
+        - "id"
+        - "external_model_id"
+        - "data_source"
+        - "publication_group_id"
+        - "accessibility_group_id"
+        - "contact_people_id"
+        - "contact_form_id"
+        - "source_database_id"
+
+  - entity: "contact_people"
+    columns:
+        - "id"
+        - "name_list"
+        - "email_list"
+
+  - entity: "contact_form"
+    columns:
+        - "id"
+        - "form_url"
+
+  - entity: "source_database"
+    columns:
+        - "id"
+        - "database_url"
+
+  - entity: "quality_assurance"
+    columns:
+        - "id"
+        - "description"
+        - "passages_tested"
+        - "validation_technique"
+        - "validation_host_strain_full"
+        - "model_id"
+
+  - entity: "patient"
+    columns:
+        - "id"
+        - "external_patient_id"
+        - "sex"
+        - "history"
+        - "ethnicity_id"
+        - "ethnicity_assessment_method"
+        - "initial_diagnosis_id"
+        - "age_at_initial_diagnosis"
+        - "provider_group_id"
+
+  - entity: "provider_group"
+    columns:
+        - "id"
+        - "name"
+        - "abbreviation"
+        - "provider_type_id"
+
+  - entity: "provider_type"
+    columns:
+        - "id"
+        - "name"
+
+  - entity: "publication_group"
+    columns:
+        - "id"
+        - "pub_med_ids"
+
+  - entity: "tissue"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "tumour_type"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "patient_sample"
+    columns:
+      - "id"
+      - "diagnosis_id"
+      - "external_patient_sample_id"
+      - "grade"
+      - "grading_system"
+      - "stage"
+      - "staging_system"
+      - "primary_site_id"
+      - "collection_site_id"
+      - "raw_data_url"
+      - "prior_treatment"
+      - "tumour_type_id"
+      - "model_id"
+
+  - entity: "xenograft_sample"
+    columns:
+      - "id"
+      - "external_xenograft_sample_id"
+
+  - entity: "patient_snapshot"
+    columns:
+      - "id"
+      - "patient_id"
+      - "age_in_years_at_collection"
+      - "collection_event"
+      - "collection_date"
+      - "months_since_collection_1"
+      - "treatment_naive_at_collection"
+      - "virology_status"
+      - "sample_id"
+
+  - entity: "engraftment_site"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "engraftment_type"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "engraftment_material"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "engraftment_sample_state"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "engraftment_sample_type"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "accessibility_group"
+    columns:
+      - "id"
+      - "europdx_access_modalities"
+      - "accessibility"
+
+  - entity: "host_strain"
+    columns:
+      - "id"
+      - "name"
+      - "nomenclature"
+
+  - entity: "project_group"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "treatment"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "response"
+    columns:
+      - "id"
+      - "description"
+      - "classification"
+
+  - entity: "molecular_characterization_type"
+    columns:
+      - "id"
+      - "name"
+
+  - entity: "platform"
+    columns:
+      - "id"
+      - "library_strategy"
+      - "provider_group_id"
+      - "instrument_model"
+      - "library_selection"
+
+  - entity: "molecular_characterization"
+    columns:
+      - "id"
+      - "molecular_characterization_type_id"
+      - "platform_id"
+      - "patient_sample_id"
+      - "xenograft_sample_id"
+

--- a/etl/entities_conf_reader.py
+++ b/etl/entities_conf_reader.py
@@ -1,0 +1,20 @@
+from functools import lru_cache
+
+import yaml
+
+
+@lru_cache(maxsize=None)
+def read_entities():
+    dic = {}
+    with open("etl/entities.yaml", "r") as ymlFile:
+        conf = yaml.safe_load(ymlFile)
+    entities = conf["entities"]
+    for entity in entities:
+        entityName = entity['entity']
+        dic[entityName] = entity['columns']
+    return dic
+
+
+def get_columns_by_entity(entity):
+    entities = read_entities()
+    return entities[entity]

--- a/etl/jobs/util/parquet_to_tsv_converter.py
+++ b/etl/jobs/util/parquet_to_tsv_converter.py
@@ -3,6 +3,7 @@ import sys
 from pyspark.sql import SparkSession
 
 from etl.constants import Constants
+from etl.entities_conf_reader import get_columns_by_entity
 
 
 def main(argv):
@@ -14,10 +15,14 @@ def main(argv):
                     [3]: Output file
     """
     parquet_path = argv[1]
-    output_path = argv[2]
+    entity = argv[2]
+    output_path = argv[3]
 
     spark = SparkSession.builder.getOrCreate()
+
     df = spark.read.parquet(parquet_path).drop(Constants.DATA_SOURCE_COLUMN)
+    columns = get_columns_by_entity(entity)
+    df = df.select(columns)
     df.coalesce(1).write \
         .option('sep', '\t') \
         .option('header', 'false') \

--- a/etl/workflow/loader.py
+++ b/etl/workflow/loader.py
@@ -111,6 +111,7 @@ class ParquetToTsv(SparkSubmitTask):
     def app_options(self):
         return [
             self.input().path,
+            self.name,
             self.output().path
         ]
 


### PR DESCRIPTION
Define explicitly the columns by table when converting parquet files to csv

- entities.yaml with the configuration of entities and columns.
- Now the parquet files are created only with those columns.
- The csvs will remain without header, as using copy_expert introduced some issues.