### PR TITLE
Add datasource column to xenograft_sample

### DIFF
--- a/etl/entities.yaml
+++ b/etl/entities.yaml
@@ -105,6 +105,7 @@ entities:
     columns:
       - "id"
       - "external_xenograft_sample_id"
+      - "data_source"
 
   - entity: "patient_snapshot"
     columns:

--- a/etl/jobs/transformation/xenograft_sample_transformer_job.py
+++ b/etl/jobs/transformation/xenograft_sample_transformer_job.py
@@ -3,6 +3,7 @@ import sys
 from pyspark.sql import DataFrame, SparkSession, Column
 from pyspark.sql.functions import col, trim
 
+from etl.constants import Constants
 from etl.jobs.util.id_assigner import add_id
 
 
@@ -13,24 +14,26 @@ def main(argv):
                     [1]: Parquet file path with raw sample platform data
                     [2]: Output file
     """
-    raw_sample_platform_parquet_path = argv[1]
+    raw_molecular_metadata_sample_parquet_path = argv[1]
     output_path = argv[2]
 
     spark = SparkSession.builder.getOrCreate()
-    raw_sample_platform_df = spark.read.parquet(raw_sample_platform_parquet_path)
-    xenograft_sample_df = transform_xenograft_sample(raw_sample_platform_df)
+    raw_molecular_metadata_sample_df = spark.read.parquet(raw_molecular_metadata_sample_parquet_path)
+    xenograft_sample_df = transform_xenograft_sample(raw_molecular_metadata_sample_df)
     xenograft_sample_df.write.mode("overwrite").parquet(output_path)
 
 
-def transform_xenograft_sample(raw_sample_platform_df: DataFrame) -> DataFrame:
-    xenograft_sample_df = get_xenograft_sample_from_sample_platform(raw_sample_platform_df)
+def transform_xenograft_sample(raw_molecular_metadata_sample_df: DataFrame) -> DataFrame:
+    xenograft_sample_df = get_xenograft_sample_from_sample_platform(raw_molecular_metadata_sample_df)
     xenograft_sample_df = add_id(xenograft_sample_df, "id")
     xenograft_sample_df = get_columns_expected_order(xenograft_sample_df)
     return xenograft_sample_df
 
 
-def get_xenograft_sample_from_sample_platform(raw_sample_platform_df: DataFrame) -> DataFrame:
-    xenograft_sample_df = raw_sample_platform_df.select("sample_id").where("sample_origin = 'xenograft'")
+def get_xenograft_sample_from_sample_platform(raw_molecular_metadata_sample_df: DataFrame) -> DataFrame:
+    xenograft_sample_df = raw_molecular_metadata_sample_df.select(
+        "sample_id", Constants.DATA_SOURCE_COLUMN).where("sample_origin = 'xenograft'")
+    xenograft_sample_df = xenograft_sample_df.withColumnRenamed(Constants.DATA_SOURCE_COLUMN, "data_source")
     xenograft_sample_df = xenograft_sample_df.drop_duplicates()
     xenograft_sample_df = xenograft_sample_df.withColumnRenamed("sample_id", "external_xenograft_sample_id")
     return xenograft_sample_df
@@ -41,7 +44,7 @@ def format_name_column(column_name) -> Column:
 
 
 def get_columns_expected_order(ethnicity_df: DataFrame) -> DataFrame:
-    return ethnicity_df.select("id", "external_xenograft_sample_id")
+    return ethnicity_df.select("id", "external_xenograft_sample_id", "data_source")
 
 
 if __name__ == "__main__":

--- a/scripts/init.sql
+++ b/scripts/init.sql
@@ -108,7 +108,9 @@ CREATE TABLE patient_sample (
 
 CREATE TABLE xenograft_sample (
     id BIGINT NOT NULL,
-    external_xenograft_sample_id TEXT
+    external_xenograft_sample_id TEXT,
+    data_source varchar
+
 );
 
 CREATE TABLE patient_snapshot (


### PR DESCRIPTION
- This allows to have a same xenograft_sample id in different providers