### PR TITLE
MMarker harmonisation

### DIFF
--- a/luigi.cfg
+++ b/luigi.cfg
@@ -1,11 +1,9 @@
 [DEFAULT]
 data_dir = /Users/mmartinez/repos/pdx/pdxfinder-data
 
-providers = ["CRL", "Curie-BC", "Curie-OC",
-            "DFCI-CPDM", "IRCC-CRC", "IRCC-GC",
-            "MDAnderson", "NKI", "PDMR", "PMLB", "PPTC",
-            "SJCRH", "TRACE", "UMCG", "UOC-BC", "UOM-BC", "VHIO-BC",
-            "VHIO-CRC", "VHIO-PC", "WUSTL", "Wistar-MDAnderson-Penn"]
+providers = ["IRCC-GC", "IRCC-CRC", "CRL", "TRACE", "Curie-BC", "Curie-LC", "Curie-OC", "PMLB",
+            "UOC-BC", "UOM-BC", "VHIO-BC", "VHIO-CRC", "DFCI-CPDM", "NKI", "PDMR", "SJCRH", "UMCG", "VHIO_PC",
+            "LIH", "PPTC", "WUSTL", "MDAndersonv", "Wistar-MDAnderson-Pennv", "HCI-BCM"]
 
 data_dir_out = output
 


### PR DESCRIPTION
- Using ncbi gene id if no approved symbol, previous symbo , alias symbol or ensembl gene id match is found
- Fix list with all providers (except JAX because the data does not match current code)