### PR TITLE
Fix bug molecular data

### DIFF
--- a/etl/jobs/transformation/cna_molecular_data_transformer_job.py
+++ b/etl/jobs/transformation/cna_molecular_data_transformer_job.py
@@ -62,15 +62,17 @@ def set_fk_molecular_characterization(cna_df: DataFrame, molecular_characterizat
         "id", "molecular_characterization_id").where("molecular_characterisation_type = 'copy number alteration'")
 
     molecular_characterization_df = molecular_characterization_df.select(
-        "molecular_characterization_id", "sample_origin", "external_patient_sample_id", "external_xenograft_sample_id")
+        "molecular_characterization_id", "sample_origin", "external_patient_sample_id",
+        "external_xenograft_sample_id", Constants.DATA_SOURCE_COLUMN)
 
     mol_char_patient_df = molecular_characterization_df.where("sample_origin = 'patient'")
     mol_char_patient_df = mol_char_patient_df.withColumnRenamed("external_patient_sample_id", "sample_id")
-    cna_patient_sample_df = mol_char_patient_df.join(cna_df, on=["sample_id"])
+    cna_patient_sample_df = cna_df.join(mol_char_patient_df, on=["sample_id", Constants.DATA_SOURCE_COLUMN], how='left')
 
     mol_char_xenograft_df = molecular_characterization_df.where("sample_origin = 'xenograft'")
     mol_char_xenograft_df = mol_char_xenograft_df.withColumnRenamed("external_xenograft_sample_id", "sample_id")
-    cna_xenograft_sample_df = mol_char_xenograft_df.join(cna_df, on=["sample_id"])
+    cna_xenograft_sample_df = cna_df.join(
+        mol_char_xenograft_df, on=["sample_id", Constants.DATA_SOURCE_COLUMN], how='left')
 
     cna_df = cna_patient_sample_df.union(cna_xenograft_sample_df)
     return cna_df

--- a/etl/jobs/transformation/expression_molecular_data_transformer_job.py
+++ b/etl/jobs/transformation/expression_molecular_data_transformer_job.py
@@ -2,6 +2,7 @@ import sys
 
 from pyspark.sql import DataFrame, SparkSession
 
+from etl.constants import Constants
 from etl.jobs.transformation.harmonisation.markers_harmonisation import harmonise_mutation_marker_symbols
 from etl.jobs.util.id_assigner import add_id
 
@@ -57,7 +58,8 @@ def get_expression_df(raw_expression_df: DataFrame) -> DataFrame:
         "symbol",
         "platform_id",
         "ensembl_gene_id",
-        "ncbi_gene_id").drop_duplicates()
+        "ncbi_gene_id",
+        Constants.DATA_SOURCE_COLUMN,).drop_duplicates()
 
 
 def set_fk_molecular_characterization(expression_df: DataFrame, molecular_characterization_df: DataFrame) -> DataFrame:
@@ -65,15 +67,18 @@ def set_fk_molecular_characterization(expression_df: DataFrame, molecular_charac
         "id", "molecular_characterization_id").where("molecular_characterisation_type = 'expression'")
 
     molecular_characterization_df = molecular_characterization_df.select(
-        "molecular_characterization_id", "sample_origin", "external_patient_sample_id", "external_xenograft_sample_id")
+        "molecular_characterization_id", "sample_origin", "external_patient_sample_id",
+        "external_xenograft_sample_id", Constants.DATA_SOURCE_COLUMN)
 
     mol_char_patient_df = molecular_characterization_df.where("sample_origin = 'patient'")
     mol_char_patient_df = mol_char_patient_df.withColumnRenamed("external_patient_sample_id", "sample_id")
-    expression_patient_sample_df = mol_char_patient_df.join(expression_df, on=["sample_id"])
+    expression_patient_sample_df = expression_df .join(
+        mol_char_patient_df, on=["sample_id", Constants.DATA_SOURCE_COLUMN])
 
     mol_char_xenograft_df = molecular_characterization_df.where("sample_origin = 'xenograft'")
     mol_char_xenograft_df = mol_char_xenograft_df.withColumnRenamed("external_xenograft_sample_id", "sample_id")
-    expression_xenograft_sample_df = mol_char_xenograft_df.join(expression_df, on=["sample_id"])
+    expression_xenograft_sample_df = expression_df.join(
+        mol_char_xenograft_df, on=["sample_id", Constants.DATA_SOURCE_COLUMN])
     expression_df = expression_patient_sample_df.union(expression_xenograft_sample_df)
     return expression_df
 


### PR DESCRIPTION
- Transformations for molecular data were producing duplicate records because the molecular characterisation transformation wasn't joining correctly with the platform dataset