### PR TITLE
Allow caching of files

### DIFF
--- a/etl/jobs/util/file_manager.py
+++ b/etl/jobs/util/file_manager.py
@@ -1,13 +1,16 @@
 import os
+from distutils.dir_util import copy_tree
 
 
-def get_not_empty_files(file_paths):
-    paths_with_non_empty_files = []
-    for path in file_paths:
-        if not is_file_emtpy(path):
-            paths_with_non_empty_files.append(path)
-    return paths_with_non_empty_files
+def copy_directory(deploy_mode, source, destination):
+    if not os.path.exists(source):
+        raise Exception("Source directory for cache [{0}] does not exist".format(source))
+    print("deploy_mode::", deploy_mode)
+    if "local" == deploy_mode:
+        print("Local copy")
+        copy_tree(source, destination)
+    else:
+        raise Exception("Deploy mode [{0}] not supported yet for copying directories".format(deploy_mode))
 
+    print("Copied cache from {0} to {1}".format(source, destination))
 
-def is_file_emtpy(file):
-    return os.stat(file).st_size == 0

--- a/etl/workflow/loader.py
+++ b/etl/workflow/loader.py
@@ -7,6 +7,7 @@ from etl.entities_registry import get_all_entities_names
 from etl.entities_task_index import get_transformation_class_by_entity_name, get_all_transformation_classes
 from etl.jobs.load.database_manager import copy_entity_to_database, get_database_connection, \
     delete_fks, delete_indexes, create_indexes, create_fks
+from etl.jobs.util.file_manager import copy_directory
 from etl.workflow.config import PdcmConfig
 
 
@@ -123,7 +124,7 @@ class CopyAll(luigi.WrapperTask):
     data_dir_out = luigi.Parameter()
 
     def requires(self):
-        return DeleteFksAndIndexes()
+        return [Cache(), DeleteFksAndIndexes()]
 
     def run(self):
         yield get_all_copying_tasks()
@@ -149,6 +150,24 @@ class ParquetToPg(SparkSubmitTask):
     def app_options(self):
         return [self.db_user, self.db_password, self.db_host, self.db_port, self.db_name,
                 "|".join(i.path for i in self.input()[1:]), "|".join(self.table_names), self.output().path]
+
+
+class Cache(luigi.Task):
+    cache = luigi.Parameter()
+    cache_dir = luigi.Parameter()
+    data_dir_out = luigi.Parameter()
+
+    def output(self):
+        return PdcmConfig().get_target("{0}/{1}".format(self.data_dir_out, "cache_checks_executed"))
+
+    def run(self):
+        use_cache = False
+        if self.cache:
+            use_cache = "yes" == str(self.cache).lower()
+        if use_cache:
+            copy_directory(PdcmConfig().deploy_mode, self.cache_dir, self.data_dir_out)
+        with self.output().open('w') as outfile:
+            outfile.write("use_cache: {0}. folder: {1}".format(use_cache, self.cache_dir))
 
 
 if __name__ == "__main__":

--- a/etl/workflow/main.py
+++ b/etl/workflow/main.py
@@ -1,6 +1,5 @@
 import luigi
 
-from etl.workflow.loader import CreateFksAndIndexes
 from etl.workflow.reporter import ExecuteAnalysis
 
 

--- a/luigi.cfg
+++ b/luigi.cfg
@@ -14,6 +14,14 @@ db_name=pdx
 db_user=pdx_admin
 db_password=pdx_admin
 
+## Settings to use a cache. The cache is just a folder with files that usually don't change (at least between releases).
+## They can include files in raw/transformed/database_formatted folders which contain parquet and csv files for
+## ontologies and biomarkers.
+
+## Set to "yes" (without quotes) to copy all the content from cache-dir dirctory to data_dir_out directory
+cache=no
+cache-dir=/path-to-cache-folder
+
 
 [PdcmConfig]
 deploy_mode=local
@@ -21,8 +29,8 @@ deploy_mode=local
 # deploy_mode=cluster
 
 [spark]
-driver_memory=6g
-executor_memory=6g
+driver_memory=4g
+executor_memory=4g
 ## Properties for running on Hadoop cluster
 # packages=org.postgresql:postgresql:42.2.12
 # driver_memory=16G
@@ -131,3 +139,5 @@ log_level = INFO
 
 [ExecuteAnalysis]
 [GenerateReport]
+
+[Cache]


### PR DESCRIPTION
- Add parameters to allow automatic copy of cached files into the output folder so the etl doesn't process that data again